### PR TITLE
Test public

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -153,6 +153,10 @@ public class DefaultDatastore implements Datastore {
       storage_ = storage;
    }
 
+   public Storage getStorage() {
+      return storage_;
+   }
+
    /**
     * Registers objects at default priority levels.
     *

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDatastore.java
@@ -153,6 +153,9 @@ public class DefaultDatastore implements Datastore {
       storage_ = storage;
    }
 
+   /**
+    * Returns the Storage of the current datastore.
+    */
    public Storage getStorage() {
       return storage_;
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -114,6 +114,9 @@ public final class MultipageTiffReader {
       fileChannel_ = fc;
    }
 
+   /**
+    * Returns the HashMap that links Coords to their byte offset. 
+    */
    public HashMap<Coords, Long> getCoordsToOffset() {
       return coordsToOffset_;
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/MultipageTiffReader.java
@@ -114,6 +114,10 @@ public final class MultipageTiffReader {
       fileChannel_ = fc;
    }
 
+   public HashMap<Coords, Long> getCoordsToOffset() {
+      return coordsToOffset_;
+   }
+
    /**
     * This constructor is used for opening datasets that have already been saved.
     */

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -175,6 +175,9 @@ public final class StorageMultipageTiff implements Storage {
       }
    }
 
+   /**
+    * Returns the Map that links Coords to their MulitpageTiffReader
+    */
    public Map<Coords, MultipageTiffReader> getCoordsToReader() {
       return coordsToReader_;
    }

--- a/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/multipagetiff/StorageMultipageTiff.java
@@ -175,6 +175,10 @@ public final class StorageMultipageTiff implements Storage {
       }
    }
 
+   public Map<Coords, MultipageTiffReader> getCoordsToReader() {
+      return coordsToReader_;
+   }
+
    /**
     * Signals the arrival of new Summary Metadata.
     *


### PR DESCRIPTION
This PR is to add three public getter methods that are necessary for the live reconstruction program developed in `mehta-lab/recOrder` on branch `main-mda-listener`.

1. `getStorage` in `DefaultDatastore` primarily to access the `StorageMultipageTiff` object when the save format is in "Image stack file". 
2. `getCoordsToReader` in `StorageMultipageTiff` to access the `MultipageTiffReader` object.
3. `getCoordsToOffset` in `MultipageTiffReader` to access the byte offsets of each image. 